### PR TITLE
Classname Fixes

### DIFF
--- a/core.liberation/gameplay_constants.sqf
+++ b/core.liberation/gameplay_constants.sqf
@@ -311,9 +311,9 @@ MSU_Eng_Div = 1;
 
 
 // ai equipment replacements
-msu_opfor_helmet = 'H_ShemagOpen_tan'; // rhs_6b27m_green VSM_ProjectHonor_OPS_2
-msu_opfor_uniform = 'VSM_M81_BDU_tan_pants_Camo'; // Alpine_white_Crye_camo VSM_ProjectHonor_Crye_SS_CamoVSM_M81_BDU_Camo 
-msu_opfor_vest = 'VSM_OGA_IOTV_1'; // rhs_6b5_rifleman_khaki VSM_LBT6094_operator_ProjectHonor
+msu_opfor_helmet = 'CUP_H_RUS_6B47_v2_GogglesClosed_Summer'; // rhs_6b27m_green VSM_ProjectHonor_OPS_2
+msu_opfor_uniform = 'CUP_U_O_RUS_Ratnik_Autumn'; // Alpine_white_Crye_camo VSM_ProjectHonor_Crye_SS_CamoVSM_M81_BDU_Camo 
+msu_opfor_vest = 'CUP_V_CZ_vest16'; // rhs_6b5_rifleman_khaki VSM_LBT6094_operator_ProjectHonor
 
 msu_civ_uniform = 'U_BG_Guerilla3_1';
 

--- a/core.liberation/mod_template/CUP_WITH_RHS_RACS/classnames_east.sqf
+++ b/core.liberation/mod_template/CUP_WITH_RHS_RACS/classnames_east.sqf
@@ -4,9 +4,9 @@ GRLIB_color_enemy = "ColorOPFOR";
 GRLIB_color_enemy_bright = "ColorRED";
 
 // Used in default_loadout.sqf for units that are defined at the bottom of this file (Units with loadout change)
-opfor_helmet = "CUP_H_RUS_Bandana_HS";
-opfor_uniform = "CUP_U_O_RUS_Gorka_Partizan";
-opfor_vest = "CUP_V_RUS_Smersh_2";
+opfor_helmet = "CUP_H_RUS_6B47_v2_GogglesClosed_Summer";
+opfor_uniform = "CUP_U_O_RUS_Ratnik_Autumn";
+opfor_vest = "CUP_V_CZ_vest16";
 
 
 // All class MUST be defined !

--- a/core.liberation/mod_template/CUP_WITH_RHS_RACS/classnames_west.sqf
+++ b/core.liberation/mod_template/CUP_WITH_RHS_RACS/classnames_west.sqf
@@ -165,7 +165,8 @@ artillery_vehicles = [
 	["rhsusf_M142_usarmy_WD", 0, 2000, msu_fuel_mbt, GRLIB_perm_inf],
 	["I_E_Truck_02_MRL_F", 0, 2500, msu_fuel_mbt, GRLIB_perm_inf],
 	["CUP_B_RM70_CZ", 0, 2500, msu_fuel_mbt, GRLIB_perm_inf],
-	["B_MBT_01_mlrs_F", 0, 3000, 0, msu_fuel_mbt, GRLIB_perm_inf]
+	["B_MBT_01_mlrs_F", 0, 3000, 0, msu_fuel_mbt, GRLIB_perm_inf],
+	["CUP_B_M270_HE_BAF_WOOD", 0, 1300, msu_fuel_ifv, GRLIB_perm_inf]
 ];
 
 apc = [
@@ -192,7 +193,6 @@ apc = [
 	["CUP_B_FV510_GB_W", 0, 1300, msu_fuel_ifv, GRLIB_perm_inf],
 	["CUP_B_MCV80_GB_W_SLAT", 0, 1300, msu_fuel_ifv, GRLIB_perm_inf],
 	["CUP_B_MCV80_GB_W", 0, 1300, msu_fuel_ifv, GRLIB_perm_inf],
-	["CUP_B_M270_HE_BAF_WOOD", 0, 1300, msu_fuel_ifv, GRLIB_perm_inf],
 	["CUP_B_M2Bradley_USA_W", 0, 1500, msu_fuel_ifv, GRLIB_perm_inf],
 	["CUP_B_M2A3Bradley_USA_W", 0, 1600, msu_fuel_ifv, GRLIB_perm_inf],
 	["CUP_B_M7Bradley_USA_W", 0, 1800, msu_fuel_ifv, GRLIB_perm_inf],


### PR DESCRIPTION
Feinde hatten noch die falschen Uniformen an
Im Baumenü wurde ein Artilleriefahrzeug als APC gelistet