### PR TITLE
Platzhalter für neue Blackhawks & Preisanpassung

### DIFF
--- a/core.liberation/mod_template/CUP_WITH_RHS_RACS/classnames_west.sqf
+++ b/core.liberation/mod_template/CUP_WITH_RHS_RACS/classnames_west.sqf
@@ -311,10 +311,11 @@ helicopter_personal_transport = [
 	[MSU_PlaceholderClassname, MSU_PlaceholderManpower, MSU_PlaceholderAmmo, MSU_PlaceholderFuel, MSU_Placeholder_RankVisible, MSU_Placeholder_Mod_BWMOD],
 	["BWA3_NH90_TTH_Fleck", 0, 400, 0, GRLIB_perm_inf],
 	["BWA3_NH90_TTH_M3M_Fleck", 0, 400, 0, GRLIB_perm_inf],
-        ["vtx_HH60", 0, 400, 0, GRLIB_perm_inf],
-        ["vtx_MH60M", 0, 400, 0, GRLIB_perm_inf],
-        ["vtx_UH60M", 0, 400, 0, GRLIB_perm_inf],
-        ["vtx_UH60M_SLICK", 0, 400, 0, GRLIB_perm_inf]
+	[MSU_PlaceholderClassname, MSU_PlaceholderManpower, MSU_PlaceholderAmmo, MSU_PlaceholderFuel, MSU_Placeholder_RankVisible, MSU_Placeholder_Mod_Other],
+	["vtx_HH60", 0, 400, 0, GRLIB_perm_inf],
+	["vtx_MH60M", 0, 400, 0, GRLIB_perm_inf],
+	["vtx_UH60M", 0, 400, 0, GRLIB_perm_inf],
+	["vtx_UH60M_SLICK", 0, 400, 0, GRLIB_perm_inf]
 ];
 
 helicopter_cargo_transport = [
@@ -432,11 +433,11 @@ drones = [
 	["B_T_UGV_01_olive_F", 0, 150, 0, GRLIB_perm_inf],
 	["B_T_UGV_01_rcws_olive_F", 0, 600, 0, GRLIB_perm_inf],
 	["B_UAV_05_F", 0, 1400, msu_fuel_plane, GRLIB_perm_inf],
-        ["B_T_UAV_03_dynamicLoadout_F", 0, 1400, msu_fuel_plane, GRLIB_perm_inf],
+	["B_T_UAV_03_dynamicLoadout_F", 0, 1400, msu_fuel_plane, GRLIB_perm_inf],
 	[MSU_PlaceholderClassname, MSU_PlaceholderManpower, MSU_PlaceholderAmmo, MSU_PlaceholderFuel, MSU_Placeholder_RankVisible, MSU_Placeholder_Mod_CUP],
-	["CUP_B_AH6X_USA", 0, 1400, msu_fuel_plane, GRLIB_perm_inf],
+	["CUP_B_AH6X_USA", 0, 600, msu_fuel_plane, GRLIB_perm_inf],
 	["CUP_B_USMC_DYN_MQ9", 0, 1400, msu_fuel_plane, GRLIB_perm_inf],
-	["CUP_O_Pchela1T_RU", 0, 1400, msu_fuel_plane, GRLIB_perm_inf],
+	["CUP_O_Pchela1T_RU", 0, 200, msu_fuel_plane, GRLIB_perm_inf],
 	[MSU_PlaceholderClassname, MSU_PlaceholderManpower, MSU_PlaceholderAmmo, MSU_PlaceholderFuel, MSU_Placeholder_RankVisible, MSU_Placeholder_Mod_USAF],
 	["USAF_RQ4A", 0, 400, msu_fuel_plane, GRLIB_perm_inf],
 	["USAF_MQ9", 0, 1400, msu_fuel_plane, GRLIB_perm_inf]


### PR DESCRIPTION
Bei den 4 neuen Blackhawks wurde ein Platzhalter hinzugefügt, sonst sah es so aus als würden die Blackhawks zum BWMod gehören.
Preise für 2 Drohnen wurden angepasst.
- Helikopterdrohne auf 600 Reduziert (Keine Bewaffnung, Sitzplätze, Steuerung kann von Pilot übernommen werden)
- Kleine Flugzeugdrohne auf 200 reduziert (Lässt sich scheiße fliegen, keine Bewaffnung, Lasermarkierer zum Aufklären)
- Neuformatierung (Tab-Einrückungen korrigiert)